### PR TITLE
Replaced deprecated Fixnum (since Ruby 2.4) with Integer

### DIFF
--- a/lib/perlin/curve.rb
+++ b/lib/perlin/curve.rb
@@ -7,7 +7,7 @@ module Perlin
     # Returns a Proc object which applies S-curve function to
     # a given number between 0 and 1.
     # @param[Proc] curve
-    # @param[Fixnum] times
+    # @param[Integer] times
     # @return[Proc]
     def self.contrast curve, times
       lambda { |n|

--- a/lib/perlin/noise.rb
+++ b/lib/perlin/noise.rb
@@ -14,8 +14,8 @@ module Perlin
       @curve = options.fetch(:curve)
       @seed = options.fetch(:seed)
 
-      raise ArgumentError.new("Invalid dimension: must be a positive integer")  unless @dim.is_a?(Fixnum) && @dim > 0
-      raise ArgumentError.new("Invalid interval: must be a positive integer")   unless @interval.is_a?(Fixnum) && @interval > 0
+      raise ArgumentError.new("Invalid dimension: must be a positive integer")  unless @dim.is_a?(Integer) && @dim > 0
+      raise ArgumentError.new("Invalid interval: must be a positive integer")   unless @interval.is_a?(Integer) && @interval > 0
       raise ArgumentError.new("Invalid curve specified: must be a Proc object") unless @curve.is_a?(Proc)
       raise ArgumentError.new("Invalid seed: must be a number")                 unless @seed.nil? || @seed.is_a?(Numeric)
 
@@ -80,4 +80,3 @@ module Perlin
     end
   end#Noise
 end#Perlin
-


### PR DESCRIPTION
see  [http://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html ](http://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html )

-Derik.